### PR TITLE
Implementing #103, optionally asking for card machine id

### DIFF
--- a/examples/emfcamp.py
+++ b/examples/emfcamp.py
@@ -184,7 +184,8 @@ cash = quicktill.cash.CashPayment(
 card = quicktill.card.CardPayment(
     'CARD', 'Card', machines=3, cashback_method=cash,
     max_cashback=Decimal("100.00"), kickout=True,
-    rollover_guard_time=datetime.time(4, 0, 0))
+    rollover_guard_time=datetime.time(4, 0, 0),
+    ask_for_machine_id=True)
 all_payment_methods = [cash, card] # Used for session totals entry
 payment_methods = all_payment_methods # Used in register
 

--- a/examples/haymakers.py
+++ b/examples/haymakers.py
@@ -221,7 +221,8 @@ card = quicktill.card.CardPayment(
     'CARD', 'Card', machines=2, cashback_method=cash,
     max_cashback=Decimal("50.00"), kickout=True,
     rollover_guard_time=datetime.time(4, 0, 0),
-    account_code="011", account_date_policy=card_expected_payment_date)
+    account_code="011", account_date_policy=card_expected_payment_date,
+    ask_for_machine_id=False)
 bitcoin = quicktill.bitcoin.BitcoinPayment(
     'BTC', 'Bitcoin', site='haymakers', username='haymakers',
     base_url='http://btcmerch.i.individualpubs.co.uk/merchantservice/',

--- a/quicktill/card.py
+++ b/quicktill/card.py
@@ -213,7 +213,7 @@ class CardPayment(payment.PaymentMethod):
                     ["The card machines 'roll over' from one day to the next at "
                      "around {}, so a card transaction performed now would be "
                      "recorded against the card totals for {}.".format(
-                         self._rollover_guard_time,date),
+                         self._rollover_guard_time, date),
                      "",
                      "The current session is for {}.".format(session.date),
                      "",

--- a/quicktill/card.py
+++ b/quicktill/card.py
@@ -14,32 +14,45 @@ class cardpopup(ui.dismisspopup):
     terminal) and whether there is any cashback on this transaction.
     """
     def __init__(self, reg, transid, amount, func, max_cashback, cashback_first,
-                 refund=False):
+                 ask_for_machine_id=False, refund=False):
         self.reg = reg
         self.transid = transid
         self.amount = amount
         self.func = func
         self.max_cashback = max_cashback
+        self.ask_for_machine_id = ask_for_machine_id
         cashback_in_use = max_cashback > zero
         h = 18 if cashback_in_use else 10
+        if cashback_in_use:
+            h = 18
+        else:
+            if ask_for_machine_id:
+                h = 12
+            else:
+                h = 10
         desc = "refund" if refund else "payment"
         ui.dismisspopup.__init__(
             self, h, 44, title="Card {} transaction {}".format(
                 desc, transid), colour=ui.colour_input)
-        self.addstr(2, 2, "Card {} of {}".format(desc, tillconfig.fc(amount)))
         if cashback_in_use:
             if cashback_first:
-                cbstart = 4
-                rnstart = 12
+                cbstart = 2
+                rnstart = 10
             else:
-                cbstart = 9
-                rnstart = 4
+                cbstart = 9 if ask_for_machine_id else 7
+                rnstart = 2
         else:
+            self.addstr(2, 2, "Card {} of {}".format(desc, tillconfig.fc(amount)))
             rnstart = 4
         self.addstr(rnstart, 2, "Please enter the receipt number from the")
         self.addstr(rnstart + 1, 2, "credit card receipt.")
-        self.addstr(rnstart + 3, 2, " Receipt number:")
-        self.rnfield = ui.editfield(rnstart + 3, 19, 16)
+
+        if ask_for_machine_id:
+            self.addstr(rnstart + 3, 2, " Machine number:")
+            self.mnfield = ui.editfield(rnstart + 3, 19, 3)
+
+        self.addstr(rnstart + (5 if ask_for_machine_id else 3), 2, " Receipt number:")
+        self.rnfield = ui.editfield(rnstart + (5 if ask_for_machine_id else 3), 19, 16)
         if cashback_in_use:
             self.addstr(cbstart, 2, "Is there any cashback?  Enter amount and")
             self.addstr(cbstart + 1, 2, "press Cash/Enter.  Leave blank and press")
@@ -54,13 +67,18 @@ class cardpopup(ui.dismisspopup):
                 firstfield = self.cbfield
                 lastfield = self.rnfield
             else:
-                firstfield = self.rnfield
+                firstfield = self.mnfield if ask_for_machine_id else self.rnfield
                 lastfield = self.cbfield
-            ui.map_fieldlist([self.rnfield,self.cbfield])
+            fieldlist = [self.rnfield, self.cbfield]
+            if ask_for_machine_id:
+                fieldlist.insert(0, self.mnfield)
+            ui.map_fieldlist(fieldlist)
         else:
             self.cbfield = None
-            firstfield = self.rnfield
+            firstfield = self.mnfield if ask_for_machine_id else self.rnfield
             lastfield = self.rnfield
+            if ask_for_machine_id:
+                ui.map_fieldlist([self.mnfield, self.rnfield])
         firstfield.keymap[keyboard.K_CLEAR] = (self.dismiss, None)
         lastfield.keymap[keyboard.K_CASH] = (self.enter, None)
         firstfield.focus()
@@ -95,20 +113,33 @@ class cardpopup(ui.dismisspopup):
         if receiptno == "":
             return ui.infopopup(["You must enter a receipt number."],
                                 title="Error")
+
+        if self.ask_for_machine_id:
+            machineno = self.mnfield.f
+            if machineno == "":
+                return ui.infopopup(["You must enter a card machine id."],
+                                    title="Error")
+            ref = "machine {}, {}".format(machineno, receiptno)
+        else:
+            ref = receiptno
         self.dismiss()
-        self.func(self.reg, self.transid, self.amount, cba, receiptno)
+        self.func(self.reg, self.transid, self.amount, cba, ref)
+
 
 class BadCashbackMethod(Exception):
     """Cashback methods must have the change_given=True attribute.
     """
     pass
 
+
 class CardPayment(payment.PaymentMethod):
     refund_supported = True
+
     def __init__(self, paytype, description, machines=1, cashback_method=None,
                  max_cashback=zero, cashback_first=True, kickout=False,
                  rollover_guard_time=None,
-                 account_code=None, account_date_policy=None):
+                 account_code=None, account_date_policy=None,
+                 ask_for_machine_id=False):
         """Accept payments using a manual PDQ machine.
 
         This payment method records the receipt number ("reference")
@@ -138,9 +169,15 @@ class CardPayment(payment.PaymentMethod):
         date will be checked against the current session's date, and
         the payment will be prevented if it would be recorded against
         the wrong day.
+
+        The ask_for_machine_id parameter sets whether the card
+        payment dialog will ask for a card machine id, which will be
+        added to the reference field. This only makes sense if you
+        have more than one machine.
         """
         payment.PaymentMethod.__init__(self, paytype, description)
         self._machines = machines
+        self._ask_for_machine_id = ask_for_machine_id if machines > 1 else False
         self._cashback_method = cashback_method
         if cashback_method and not cashback_method.change_given:
             raise BadCashbackMethod()
@@ -195,7 +232,8 @@ class CardPayment(payment.PaymentMethod):
                     title="Refund too large")
                 return
             cardpopup(reg, transid, amount, self._finish_payment, zero,
-                      self._cashback_first, refund=True)
+                      self._cashback_first, self._ask_for_machine_id,
+                      refund=True)
             return
         if amount > outstanding:
             if self._cashback_method:
@@ -212,7 +250,7 @@ class CardPayment(payment.PaymentMethod):
             return
         cardpopup(reg, transid, amount, self._finish_payment,
                   self._max_cashback if self._cashback_method else zero,
-                  self._cashback_first)
+                  self._cashback_first, self._ask_for_machine_id)
 
     def _finish_payment(self, reg, transid, amount, cashback, ref):
         trans = td.s.query(Transaction).get(transid)

--- a/quicktill/card.py
+++ b/quicktill/card.py
@@ -5,16 +5,6 @@ from .models import Session, Payment, Transaction, zero, penny
 from decimal import Decimal
 import datetime
 
-# XXX this should be replaced with ui.moneyfield
-class moneyfield(ui.editfield):
-    def __init__(self, y, x, w):
-        ui.editfield.__init__(self, y, x, w, validate=ui.validate_float)
-    def keypress(self, k):
-        if hasattr(k, "notevalue"):
-            self.set(str(k.notevalue))
-            ui.editfield.keypress(self, keyboard.K_CASH)
-        else:
-            ui.editfield.keypress(self, k)
 
 class cardpopup(ui.dismisspopup):
     """Ask for card payment details
@@ -55,8 +45,8 @@ class cardpopup(ui.dismisspopup):
             self.addstr(cbstart + 1, 2, "press Cash/Enter.  Leave blank and press")
             self.addstr(cbstart + 2, 2, "Cash/Enter if there is none.")
             self.addstr(cbstart + 4, 2, "Cashback amount: %s" % tillconfig.currency)
-            # XXX use ui.moneyfield instead
-            self.cbfield = moneyfield(cbstart + 4, 19 + len(tillconfig.currency), 6)
+
+            self.cbfield = ui.moneyfield(cbstart + 4, 19 + len(tillconfig.currency), 6)
             self._total_line = cbstart + 6
             self.cbfield.sethook = self.update_total_amount
             self.update_total_amount()

--- a/quicktill/ui.py
+++ b/quicktill/ui.py
@@ -9,6 +9,7 @@ import traceback
 from . import keyboard, tillconfig, td
 from .td import func
 import sqlalchemy.inspection
+from decimal import Decimal
 
 import logging
 log = logging.getLogger(__name__)
@@ -1599,8 +1600,9 @@ class moneyfield(editfield):
     If a "note value" key is pressed, this auto-fills that amount into
     the field.
     """
-    def __init__(self, y, x, w=6):
-        super().__init__(y, x, w, validate=ui.validate_float)
+    def __init__(self, y, x, w=6, default=""):
+        super().__init__(y, x, w, validate=validate_float)
+        self.set(default)
 
     def keypress(self, k):
         if hasattr(k, "notevalue"):

--- a/quicktill/ui.py
+++ b/quicktill/ui.py
@@ -1363,7 +1363,7 @@ class booleanfield(valuefield):
             self.set(None)
         else:
             super().keypress(k)
-                
+
 class editfield(valuefield):
     """Accept typed-in input in a field.
 
@@ -1731,7 +1731,7 @@ class modelpopupfield(valuefield):
 
     popupfunc is a function that takes two arguments: the function to
     call when a value is chosen, and the current value of the field.
-    
+
     valuefunc is a function that takes one argument: the current value
     of the field.  It returns a string to display.  It is never passed
     None as an argument.


### PR DESCRIPTION
While I was at it, I also made sure the card dialog now uses `ui.moneyfield` as suggested by the comment in card.py.

I made sure to manually test all the cases (cashback / no cashback; cashback first / last; refunds) with `ask_for_machine_id` on and off using the gtk backend. I might have missed something but am 90% confident that it should be fine.

I am not sure that it will look fine using the curses backend; and I fear I cannot test that easily, lacking a hardware keyboard.